### PR TITLE
Change sh_minversion to 1.5.1

### DIFF
--- a/openweathermap/plugin.yaml
+++ b/openweathermap/plugin.yaml
@@ -13,7 +13,7 @@ plugin:
     support: 'https://knx-user-forum.de/forum/supportforen/smarthome-py/1246998-support-thread-zum-openweathermap-plugin'
     keywords: weather
     version: 1.5.0.3              # Plugin version
-    sh_minversion: 1.5b           # minimum shNG version to use this plugin
+    sh_minversion: 1.5.1           # minimum shNG version to use this plugin
 #    sh_maxversion:               # maximum shNG version to use this plugin (leave empty if latest)
     multi_instance: True          # plugin supports multi instance
     restartable: unknown


### PR DESCRIPTION
As smarthome-ng 1.5b does not exist and appearently, 1.5.1 is not assumed greater than 1.5b, it is currently impossible to use this plugin.